### PR TITLE
Add state token support in authorization_url

### DIFF
--- a/lib/ledger_sync/quickbooks_online/client.rb
+++ b/lib/ledger_sync/quickbooks_online/client.rb
@@ -59,8 +59,8 @@ module LedgerSync
         super()
       end
 
-      def authorization_url(redirect_uri:)
-        oauth_client.authorization_url(redirect_uri: redirect_uri)
+      def authorization_url(redirect_uri:, state: SecureRandom.hex(12))
+        oauth_client.authorization_url(redirect_uri: redirect_uri, state: state)
       end
 
       def find(path:)

--- a/lib/ledger_sync/quickbooks_online/oauth_client.rb
+++ b/lib/ledger_sync/quickbooks_online/oauth_client.rb
@@ -50,11 +50,11 @@ module LedgerSync
         @client_secret = client_secret
       end
 
-      def authorization_url(redirect_uri:)
+      def authorization_url(redirect_uri:, state: SecureRandom.hex(12))
         client.auth_code.authorize_url(
           redirect_uri: redirect_uri,
           response_type: 'code',
-          state: SecureRandom.hex(12),
+          state: state,
           scope: 'com.intuit.quickbooks.accounting'
         )
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -137,19 +137,26 @@ RSpec.describe LedgerSync::QuickBooksOnline::Client do
 
   describe '.new_from_oauth_client_uri', vcr: true do
     it do
+      oauth_client_uri =
+        'http://localhost:3000/?code=THIS_IS_THE_OAUTH_CODE&state=1f14489339926f9ac94cb860&realmId=1234567890'
+      redirect_uri = 'http://localhost:3000/accounting/'
       oauth_client = LedgerSync::QuickBooksOnline::OAuthClient.new(
         client_id: 'client_id',
         client_secret: 'client_secret'
       )
       client = described_class.new_from_oauth_client_uri(
         oauth_client: oauth_client,
-        uri: 'http://localhost:3000/?code=THIS_IS_THE_OAUTH_CODE&state=1f14489339926f9ac94cb860&realmId=1234567890'
+        uri: oauth_client_uri
       )
 
       expect(client.access_token).to be_present
       expect(client.client_id).to eq(oauth_client.client_id)
       expect(client.realm_id).to be_present
       expect(client.refresh_token).to be_present
+
+      state_token = SecureRandom.hex(12)
+      authorization_url = oauth_client.authorization_url(redirect_uri: redirect_uri, state: state_token)
+      expect(authorization_url).to include("state=#{state_token}")
     end
   end
 end


### PR DESCRIPTION
The current implementation of `authorization_url` does not allow for user-specified state tokens (they are randomly generated). State tokens allow users to verify that the same session kicking off the OAuth flow also completes it, which is  essential to mitigate security vulnerabilities like replay attacks.    