### PR TITLE
Schedule a release every two weeks

### DIFF
--- a/.github/workflows/gem-workflow.yml
+++ b/.github/workflows/gem-workflow.yml
@@ -58,7 +58,7 @@ jobs:
           parallel: true
           flag-name: run-${{ matrix.ruby-version }}
   create_release:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This should schedule an automated release every two weeks, and then the publish step is triggered to publish to ruby gems.